### PR TITLE
fix: handle flat fn* forms from #() anonymous functions

### DIFF
--- a/spy/src/tommy_mor/spy.clj
+++ b/spy/src/tommy_mor/spy.clj
@@ -6,26 +6,29 @@
 
 (defn inject-spy-defs [form]
   (walk/postwalk
-    (fn [form]
-      (cond 
-        (and (seq? form) (= (first form) 'let*))
-        (let [bvec (second form)
-              body (drop 2 form)
-              syms (filter should-spy? (take-nth 2 bvec))
-              def-forms (map (fn [sym] `(def ~sym ~sym)) syms)]
-          `(let* ~bvec 
-             ~@def-forms
-             ~@body))
+   (fn [form]
+     (cond
+       (and (seq? form) (= (first form) 'let*))
+       (let [bvec (second form)
+             body (drop 2 form)
+             syms (filter should-spy? (take-nth 2 bvec))
+             def-forms (map (fn [sym] `(def ~sym ~sym)) syms)]
+         `(let* ~bvec
+            ~@def-forms
+            ~@body))
 
-        (and (seq? form) (= (first form) 'fn*))
-        (let [arglists (rest form)
-              spy-arglist (fn [[args & body]]
+       (and (seq? form) (= (first form) 'fn*))
+       (let [arglists (let [rst (rest form)]
+                        (if (vector? (first rst))
+                          (list rst)      ; flat: (fn* [args] body) → wrap it
+                          rst))           ; multi-arity: already list of arities
+             spy-arglist (fn [[args & body]]
                            (let [def-forms (map (fn [sym] `(def ~sym ~sym)) args)]
                              `(~args ~@def-forms ~@body)))]
-          `(fn* ~@(map spy-arglist arglists)))
+         `(fn* ~@(map spy-arglist arglists)))
 
-        :else form))
-    form))
+       :else form))
+   form))
 
 (defmacro spy [& body]
   (let [expanded (walk/macroexpand-all `(do ~@body))]
@@ -39,16 +42,16 @@
 (comment
   ;; Example 1: Simple let bindings 
   (spy
-    (let [x 10
-          y 20
-          z (+ x y)]
-      (println "x =" x)
-      (println "y =" y)
-      (println "z =" z)
-      (* x y z)))
+   (let [x 10
+         y 20
+         z (+ x y)]
+     (println "x =" x)
+     (println "y =" y)
+     (println "z =" z)
+     (* x y z)))
 
   ;; Example 2: Destructuring
-  (spy 
+  (spy
    (let [{:keys [a b]} {:a 1 :b 2}
          sum (+ a b)]
      (println "sum =" sum)

--- a/spy/test/tommy_mor/spy_test.clj
+++ b/spy/test/tommy_mor/spy_test.clj
@@ -12,8 +12,6 @@
   (is (= y 20))
   (is (= z 30)))
 
-
-
 (deftest test-destructuring
   (spy
    (is (= 21 (let [{:keys [a b]} {:a 5 :b 15}
@@ -40,7 +38,7 @@
 (deftest test-redefining-core
   ;; watch out 
   (is (= (count [1 2 3]) 3))
-  
+
   (spy
    (let [count 5]
      (is (= 5 count))))
@@ -53,6 +51,15 @@
      (+ a b c)))
   (is (= 306 (test-fn 101 {:b 102 :c 103})))
   (is (= 306 (+ a b c))))
+
+(deftest test-anonymous-fn
+  ;; #() shorthand macroexpands to flat (fn* [args] body), not multi-arity form
+  ;; spy should handle both without ClassCastException
+  (let [nums [1 2 3]
+        doubled (map #(* 2 %) nums)]
+    (spy
+     (let [result (filter #(> % 3) doubled)]
+       (is (= (list 4 6) result))))))
 
 (defn -main []
   (run-tests 'tommy-mor.spy-test))


### PR DESCRIPTION
## Summary

- `#()` macroexpands to flat `(fn* [args] body)`, but `inject-spy-defs` assumed all `fn*` forms use the multi-arity `(fn* ([args] body))` shape, causing a `ClassCastException`
- Fix detects whether the first element after `fn*` is a vector (flat form) and wraps it in a list to normalize before processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)